### PR TITLE
adding script to create data/clean if needed

### DIFF
--- a/alerts/scripts/create_dir_data_clean.R
+++ b/alerts/scripts/create_dir_data_clean.R
@@ -1,0 +1,7 @@
+
+## This will create a clean data folder in `data/clean` if it does not exist
+
+clean_path <- here::here("data", "clean")
+if (!dir.exists(clean_path)) {
+  dir.create(clean_path, recursive = TRUE)
+}

--- a/compare_data/scripts/create_dir_data_clean.R
+++ b/compare_data/scripts/create_dir_data_clean.R
@@ -1,0 +1,7 @@
+
+## This will create a clean data folder in `data/clean` if it does not exist
+
+clean_path <- here::here("data", "clean")
+if (!dir.exists(clean_path)) {
+  dir.create(clean_path, recursive = TRUE)
+}

--- a/godata/scripts/create_dir_data_clean.R
+++ b/godata/scripts/create_dir_data_clean.R
@@ -1,0 +1,7 @@
+
+## This will create a clean data folder in `data/clean` if it does not exist
+
+clean_path <- here::here("data", "clean")
+if (!dir.exists(clean_path)) {
+  dir.create(clean_path, recursive = TRUE)
+}

--- a/linelist_investigations/scripts/create_dir_data_clean.R
+++ b/linelist_investigations/scripts/create_dir_data_clean.R
@@ -1,0 +1,7 @@
+
+## This will create a clean data folder in `data/clean` if it does not exist
+
+clean_path <- here::here("data", "clean")
+if (!dir.exists(clean_path)) {
+  dir.create(clean_path, recursive = TRUE)
+}

--- a/transmission_chains/scripts/create_dir_data_clean.R
+++ b/transmission_chains/scripts/create_dir_data_clean.R
@@ -1,0 +1,7 @@
+
+## This will create a clean data folder in `data/clean` if it does not exist
+
+clean_path <- here::here("data", "clean")
+if (!dir.exists(clean_path)) {
+  dir.create(clean_path, recursive = TRUE)
+}


### PR DESCRIPTION
This adds a simple script to all factories to add a `data/clean` folder if it does not exist. This will work also if `data/` does not exist, in which case it creates `data` and `data/clean`