### PR TITLE
update mangina and mambassa alerts

### DIFF
--- a/alerts/report_sources/alerts_mambasa_2019-12-10.Rmd
+++ b/alerts/report_sources/alerts_mambasa_2019-12-10.Rmd
@@ -2535,16 +2535,55 @@ outcomes_recent %>%
 ###Percentage of final status by alert status decision for the past 21 days
 
 
-Only non-cases for the past 21 days as of teh database of October 14th 2019.
+Only non-cases for the past 21 days as of the database of October 14th 2019.
+
+```{r final_status_percentage_recent}
+cas <- unique(outcomes_recent$final_outcome)
+
+if(length(which(cas%in%c("confirme")))==0){
+  print("non-cases only")
+}else{
+perc_final_outcome_recent <- outcomes_recent %>%
+  filter(!is.na(final_outcome)) %>%
+  count(top_zones, decision_comparison, final_outcome) %>%
+  spread(final_outcome, n, fill = 0) %>% 
+  mutate(total= confirme + non_cas + suspect,
+         perc_confirme = prop_to_perc(confirme/total),
+         perc_suspect = prop_to_perc(suspect/total),
+         perc_non_cas = prop_to_perc(non_cas/total)) %>%
+  pivot_longer(cols = starts_with("perc"),
+               names_to = "Proportion") 
+
+
+
+perc_final_outcome_recent %>% 
+  ggplot(aes(x = decision_comparison, y= value, fill= Proportion)) +
+  geom_col(color = "white")  +
+  scale_final_outcome_perc +
+  scale_x_discrete(drop = FALSE) +
+  facet_grid(. ~ top_zones , scales = "free_y")+
+  guides(fill = guide_legend(ncol = 2)) +
+  labs(x = "",
+       y = "Pourcentage d'alertes\n",
+       title = "Distribution des alertes par statut final, \ndécision de validation et par zone de santé",
+       subtitle= "Données des 3 dernières semaines") +
+  theme(legend.position = "bottom") +
+  large_txt +
+  rotate_x_text(45)
+}
+```
 
 
 ### Table - final status overall
+Only non-cases for the past 21 days as of the database of October 14th 2019.
 
 ```{r table_final_status, fig.keep = "all"}
-
+if(length(which(cas%in%c("confirme")))==0){
+  print("non-cases only")
+}else{
 perc_final_outcome %>%
   show_table()
-
+}
 ```
 
 
@@ -2552,10 +2591,12 @@ perc_final_outcome %>%
 ### Table - final status for the past 21 days
 
 ```{r table_final_status_recent, fig.keep = "all"}
-
+if(length(which(cas%in%c("confirme")))==0){
+  print("non-cases only")
+}else{
 perc_final_outcome_recent %>%
   show_table()
-
+}
 ```
 
 <!-- ======================================================= -->
@@ -2667,10 +2708,15 @@ to_export <- c("cleaned_alerts_database_mambasa",
                "table_ha_over_time_decisions",
                "table_ha_total_recent_decisions",
                "table_ha_over_time_recent_decisions",
-               "perc_final_outcome",
-                "perc_final_outcome_recent",
                "table_unknown_as")
-               
+
+if(length(which(cas%in%c("confirme")))==0){
+  print("non-cases only")
+}else{
+  to_export <- c(to_export,
+                 "perc_final_outcome",
+                "perc_final_outcome_recent")
+}               
 ```
 
 ```{r xlsx_exports, eval = TRUE}

--- a/alerts/report_sources/alerts_mangina_2019-12-10.Rmd
+++ b/alerts/report_sources/alerts_mangina_2019-12-10.Rmd
@@ -2485,7 +2485,19 @@ ggplot(aes(x = decision_comparison, fill = final_outcome)) +
 ###Percentage of final status by alert status decision 
 
 ```{r final_status_percentage}
+cas <- unique(outcomes$final_outcome)
 
+if(length(which(cas%in%c("suspect")))==0){
+  perc_final_outcome <- outcomes %>%
+    filter(!is.na(final_outcome)) %>%
+  count(top_zones, decision_comparison, final_outcome) %>%
+  spread(final_outcome, n, fill = 0) %>% 
+  mutate(total= confirme + non_cas,
+    perc_confirme = prop_to_perc(confirme/total),
+         perc_non_cas = prop_to_perc(non_cas/total)) %>%
+      pivot_longer(cols = starts_with("perc"),
+   names_to = "Proportion")
+}else{
 perc_final_outcome <- outcomes %>%
     filter(!is.na(final_outcome)) %>%
   count(top_zones, decision_comparison, final_outcome) %>%
@@ -2496,7 +2508,7 @@ perc_final_outcome <- outcomes %>%
     perc_suspect = prop_to_perc(suspect/total)) %>%
       pivot_longer(cols = starts_with("perc"),
    names_to = "Proportion") 
-
+}
 
 perc_final_outcome %>% 
 ggplot(aes(x = decision_comparison, y= value, fill= Proportion)) +
@@ -2521,7 +2533,6 @@ ggplot(aes(x = decision_comparison, y= value, fill= Proportion)) +
 
 ```{r final_status_recent}
 
-
 outcomes_recent %>% 
     filter(!is.na(final_outcome)) %>%
 ggplot(aes(x = decision_comparison, fill = final_outcome)) +
@@ -2538,14 +2549,24 @@ ggplot(aes(x = decision_comparison, fill = final_outcome)) +
   large_txt +
   rotate_x_text(45) 
 
-
 ```
 
 
 ###Percentage of final status by alert status decision for the past 21 days
 
 ```{r final_status_percentage_recent}
+cas <- unique(outcomes_recent$final_outcome)
 
+if(length(which(cas%in%c("suspect")))==0){
+  perc_final_outcome_recent <- outcomes_recent %>%
+    filter(!is.na(final_outcome)) %>%
+  count(top_zones, decision_comparison, final_outcome) %>%
+  spread(final_outcome, n, fill = 0) %>% 
+  mutate(total= confirme,
+    perc_confirme = prop_to_perc(confirme/total)) %>%
+      pivot_longer(cols = starts_with("perc"),
+   names_to = "Proportion") 
+}else{
 perc_final_outcome_recent <- outcomes_recent %>%
     filter(!is.na(final_outcome)) %>%
   count(top_zones, decision_comparison, final_outcome) %>%
@@ -2555,7 +2576,7 @@ perc_final_outcome_recent <- outcomes_recent %>%
     perc_suspect = prop_to_perc(suspect/total)) %>%
       pivot_longer(cols = starts_with("perc"),
    names_to = "Proportion") 
-
+}
 
 
 perc_final_outcome_recent %>% 


### PR DESCRIPTION
For Mambasa:

- Fixed 'percentage of final status by alert status decision section for last 21 days' (end of script). Added ifelse statement for not plotting and creating table if non-cases only

For Mangina:
- Fixed 'percentage of final status by alert status decision sections (end of script). Added ifelse statement for removing suspected if non-cases and suspected cases only.